### PR TITLE
Feat: customize reportDir

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ const { merge } = require('mochawesome-merge')
 
 // See Options below
 const options = {
+  rootDir: process.cwd(),
   reportDir: 'report',
 }
 merge(options).then(report => {
@@ -37,12 +38,15 @@ merge(options).then(report => {
 ## CLI
 
 ```
-$ mochawesome-merge --reportDir [directory] > output.json
+$ mochawesome-merge --rootDir [rootDirectory] --reportDir [directory] > output.json
 ```
 
 ## Options
 
+- `rootDir` (optional) — source mochawesome JSON reports root directory. Defaults to `process.cwd()`.
 - `reportDir` (optional) — source mochawesome JSON reports directory. Defaults to `mochawesome-report`.
+
+The final mochawesome JSON reports will be in `path.resolve(rootDir, reportDir)`.
 
 ## [Cypress](https://github.com/cypress-io/cypress)
 

--- a/bin/mochawesome-merge.js
+++ b/bin/mochawesome-merge.js
@@ -1,7 +1,15 @@
 #!/usr/bin/env node
 const { merge } = require('../lib/index')
 
-const { argv } = require('yargs').option('reportDir')
+const { argv } = require('yargs')
+  .option('rootDir', {
+    type: 'string',
+    description: 'source mochawesome JSON reports root directory.',
+  })
+  .option('reportDir', {
+    type: 'string',
+    description: 'source mochawesome JSON reports directory.',
+  })
 
 merge(argv).then(
   report => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -50,9 +50,10 @@ const getAllTests = flatMap(suite => [
 ])
 
 exports.merge = async function merge({
+  rootDir = process.cwd(),
   reportDir = 'mochawesome-report',
 } = {}) {
-  const dir = path.resolve(process.cwd(), reportDir)
+  const dir = path.resolve(rootDir, reportDir)
   const reports = await collectReportFiles(dir)
   const suites = collectReportSuites(reports)
   return {

--- a/tests/merge.js
+++ b/tests/merge.js
@@ -4,6 +4,7 @@ const path = require('path')
 describe('merge', () => {
   test('merges configs', async () => {
     const report = await merge({
+      rootDir: process.cwd(),
       reportDir: path.resolve(__dirname, './mochawesome-report'),
     })
     const suites = report.results


### PR DESCRIPTION
Hey guys, thanks for the great work of `mochawesome-merge`.

 I've found for `reportDir` option, it was assigned to `path.resolve(process.cwd(), reportDir)`. But sometimes we need to specify `reportDir` to some other path which is not based on the current working directory of the Node.js process. 

so `const dir = path.resolve(process.cwd(), reportDir)` is actually not 100% customized. I've made the PR to add a `useCwd` option which will enable developer to customized the `reportDir`(actually I need this for my project).

Thanks again and wait for your reply