### PR TITLE
fix(cli): accept list of source files

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ const { merge } = require('mochawesome-merge')
 
 // See Options below
 const options = {
-  reportsGlob: './report/*.json',
+  files: ['./report/*.json'],
 }
 
 merge(options).then(report => {
@@ -38,12 +38,12 @@ merge(options).then(report => {
 ## CLI
 
 ```
-$ mochawesome-merge [reportsGlob] > output.json
+$ mochawesome-merge [file...] > output.json
 ```
 
 ## Arguments
 
-- `reportsGlob`: glob pattern for source mochawesome JSON reports. [string] [default: "./mochawesome-report/mochawesome*.json"]
+- `files`: list of source report file paths. Can include glob patterns. Defaults to `["./mochawesome-report/mochawesome*.json"]`.
 
 ## [Cypress](https://github.com/cypress-io/cypress)
 

--- a/bin/mochawesome-merge.js
+++ b/bin/mochawesome-merge.js
@@ -2,18 +2,7 @@
 
 const { merge } = require('../lib/index')
 
-const { argv } = require('yargs').command(
-  '$0 [reportsGlob]',
-  'Merge several Mochawesome JSON reports',
-  yargs =>
-    yargs.positional('reportsGlob', {
-      type: 'string',
-      default: './mochawesome-report/mochawesome*.json',
-      description: 'glob pattern for source mochawesome JSON reports.',
-    })
-)
-
-merge(argv).then(
+merge({ files: process.argv.slice(2) }).then(
   report => {
     process.stdout.write(JSON.stringify(report, null, 2))
   },

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,20 @@ const fse = require('fs-extra')
 const glob = require('glob')
 const { flatMap } = require('./utils')
 
+function resolveOptions({ files = [] } = {}) {
+  return {
+    files: files.length ? files : ['./mochawesome-report/mochawesome*.json'],
+  }
+}
+
+const collectSourceFiles = flatMap(pattern => {
+  const files = glob.sync(pattern)
+  if (!files.length) {
+    throw new Error(`Pattern ${pattern} matched no report files`)
+  }
+  return files
+})
+
 function generateStats(suites) {
   const tests = getAllTests(suites)
   const passes = tests.filter(test => test.pass)
@@ -27,13 +41,7 @@ function generateStats(suites) {
   }
 }
 
-function collectReportFiles(reportsGlob) {
-  const files = glob.sync(reportsGlob)
-
-  if (files.length === 0) {
-    throw new Error(`Pattern ${reportsGlob} matched no report files`)
-  }
-
+function collectReportFiles(files) {
   return Promise.all(files.map(filename => fse.readJson(filename)))
 }
 
@@ -46,10 +54,10 @@ const getAllTests = flatMap(suite => [
   ...getAllTests(suite.suites),
 ])
 
-exports.merge = async function merge({
-  reportsGlob = './mochawesome-report/mochawesome*.json',
-} = {}) {
-  const reports = await collectReportFiles(reportsGlob)
+exports.merge = async function merge(options) {
+  options = resolveOptions(options)
+  const files = collectSourceFiles(options.files)
+  const reports = await collectReportFiles(files)
   const suites = collectReportSuites(reports)
 
   return {

--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
   "dependencies": {
     "fs-extra": "^7.0.1",
     "glob": "^7.1.6",
-    "uuid": "^3.3.2",
-    "yargs": "^12.0.5"
+    "uuid": "^3.3.2"
   },
   "devDependencies": {
     "codecov": "^3.1.0",

--- a/tests/merge.js
+++ b/tests/merge.js
@@ -3,7 +3,7 @@ const { merge } = require('../lib')
 describe('merge', () => {
   test('merges configs', async () => {
     const report = await merge({
-      reportsGlob: `./tests/mochawesome-report/mochawesome*.json`,
+      files: [`./tests/mochawesome-report/mochawesome*.json`],
     })
     const suites = report.results
 
@@ -29,7 +29,7 @@ describe('merge', () => {
   test('throws when invalid directory provided', async () => {
     const reportsGlob = './invalid-directory/mochawesome*.json'
 
-    await expect(merge({ reportsGlob })).rejects.toEqual(
+    await expect(merge({ files: [reportsGlob] })).rejects.toEqual(
       new Error(`Pattern ${reportsGlob} matched no report files`)
     )
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -7169,7 +7169,7 @@ yargs@^11.0.0:
     y18n "^3.2.1"
     yargs-parser "^9.0.2"
 
-yargs@^12.0.0, yargs@^12.0.5:
+yargs@^12.0.0:
   version "12.0.5"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-12.0.5.tgz#05f5997b609647b64f66b81e3b4b10a368e7ad13"
   integrity sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==


### PR DESCRIPTION
BREAKING CHANGE: options schema changed.
Now it supports the optional `files` property, which should include paths to all source report files.
Can contain glob patterns.

fixes: #33