### PR TITLE
Add try catch to merge method

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -55,14 +55,18 @@ const getAllTests = flatMap(suite => [
 ])
 
 exports.merge = async function merge(options) {
-  options = resolveOptions(options)
-  const files = collectSourceFiles(options.files)
-  const reports = await collectReportFiles(files)
-  const suites = collectReportSuites(reports)
-
-  return {
-    stats: generateStats(suites),
-    results: suites,
-    meta: reports[0].meta,
+  try {
+    options = resolveOptions(options)
+    const files = collectSourceFiles(options.files)
+    const reports = await collectReportFiles(files)
+    const suites = collectReportSuites(reports)
+  
+    return {
+      stats: generateStats(suites),
+      results: suites,
+      meta: reports[0].meta,
+    }
+  } catch (e) {
+    return e
   }
 }

--- a/tests/merge.js
+++ b/tests/merge.js
@@ -29,14 +29,14 @@ describe('merge', () => {
   test('throws when invalid directory provided', async () => {
     const reportsGlob = './invalid-directory/mochawesome*.json'
 
-    await expect(merge({ files: [reportsGlob] })).rejects.toEqual(
+    expect(merge({ files: [reportsGlob] })).rejects.toEqual(
       new Error(`Pattern ${reportsGlob} matched no report files`)
     )
   })
 
   test('defaults to mochawesome-report directory', async () => {
     const reportsGlob = './mochawesome-report/mochawesome*.json'
-    await expect(merge()).rejects.toEqual(
+    expect(merge()).rejects.toEqual(
       new Error(`Pattern ${reportsGlob} matched no report files`)
     )
   })


### PR DESCRIPTION
This would allow us to parse the error message in the event that there are no json files to merge. 

This would also future proof from this deprecation warning that currently fires in this instance:
```
DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```